### PR TITLE
Various updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ resource "aws_ssm_parameter" "pipeline-ci-user-key" {
 resource "aws_iam_user_policy" "s3_write_for_user" {
   count       = length(var.allowed_s3_write_arns) > 0 ? 1 : 0
   name_prefix = "${var.name_prefix}-circleci-s3-write"
+  user        = aws_iam_user.circle_ci_machine-user.name
   policy      = data.aws_iam_policy_document.s3_write_for_user.json
 }
 

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "aws_ssm_parameter" "pipeline-ci-user-key" {
 resource "aws_iam_user_policy" "s3_write_for_user" {
   count       = length(var.allowed_s3_write_arns) > 0 ? 1 : 0
   name_prefix = "${var.name_prefix}-circleci-s3-write"
-  policy      = data.aws_iam_policy_document.s3_write_to_user.json
+  policy      = data.aws_iam_policy_document.s3_write_for_user.json
 }
 
 resource "aws_iam_user_policy" "ecr_to_user" {

--- a/main.tf
+++ b/main.tf
@@ -33,13 +33,13 @@ resource "aws_iam_user_policy" "s3_write_for_user" {
 resource "aws_iam_user_policy" "ecr_to_user" {
   count       = length(var.allowed_ecr_arns) > 0 ? 1 : 0
   description = "This policy allows push access to specific ECR repos."
-  user        = aws_iam_user.circle_ci_machine_user.name
+  user        = aws_iam_user.circle_ci_machine-user.name
   policy      = data.aws_iam_policy_document.ecr_for_user.json
 }
 
 resource "aws_iam_user_policy" "s3_read_for_user" {
   count       = length(var.allowed_s3_read_arns) > 0 ? 1 : 0
   description = "This policy allows read access to specific S3 buckets."
-  user        = aws_iam_user.circle_ci_machine_user.name
+  user        = aws_iam_user.circle_ci_machine-user.name
   policy      = data.aws_iam_policy_document.s3_read_for_user.json
 }

--- a/main.tf
+++ b/main.tf
@@ -25,76 +25,22 @@ resource "aws_ssm_parameter" "pipeline-ci-user-key" {
   key_id = var.ci_parameters_key
 }
 
-resource "aws_iam_policy" "push_to_s3" {
-  count       = var.allowed_s3_count
-  name_prefix = "${var.name_prefix}-push-to-repos"
-  description = "This policy allows push access to specific repos"
-  policy      = data.aws_iam_policy_document.push_to_s3.json
+resource "aws_iam_user_policy" "s3_write_for_user" {
+  count       = length(var.allowed_s3_write_arns) > 0 ? 1 : 0
+  description = "This policy allows push and list access to specific S3 buckets."
+  policy      = data.aws_iam_policy_document.s3_write_to_user.json
 }
 
-resource "aws_iam_policy" "push_to_ecr" {
-  count       = var.allowed_ecr_count
-  name_prefix = "${var.name_prefix}-push-to-repos"
-  description = "This policy allows push access to specific repos"
-  policy      = data.aws_iam_policy_document.push_to_ecr.json
+resource "aws_iam_user_policy" "ecr_to_user" {
+  count       = length(var.allowed_ecr_arns) > 0 ? 1 : 0
+  description = "This policy allows push access to specific ECR repos."
+  user        = aws_iam_user.circle_ci_machine_user.name
+  policy      = data.aws_iam_policy_document.ecr_for_user.json
 }
 
-
-
-data "aws_iam_policy_document" "push_to_ecr" {
-  version = "2012-10-17"
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetRepositoryPolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-      "ecr:BatchGetImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:PutImage",
-    ]
-    resources = var.allowed_ecr_arns
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "ecr:GetAuthorizationToken",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "push_to_s3" {
-  version = "2012-10-17"
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "s3:PutObject",
-      "s3:List*",
-    ]
-    resources = concat(var.allowed_s3_arns, formatlist("%s/*", var.allowed_s3_arns))
-  }
-}
-
-resource "aws_iam_user_policy_attachment" "ecr-to-ci-machine-user" {
-  count      = var.allowed_ecr_count > 0 ? 1 : 0
-  user       = aws_iam_user.circle_ci_machine-user.name
-  policy_arn = aws_iam_policy.push_to_ecr[0].arn
-}
-
-resource "aws_iam_user_policy_attachment" "s3-to-ci-machine-user" {
-  count      = var.allowed_s3_count > 0 ? 1 : 0
-  user       = aws_iam_user.circle_ci_machine-user.name
-  policy_arn = aws_iam_policy.push_to_s3[0].arn
+resource "aws_iam_user_policy" "s3_read_for_user" {
+  count       = length(var.allowed_s3_read_arns) > 0 ? 1 : 0
+  description = "This policy allows read access to specific S3 buckets."
+  user        = aws_iam_user.circle_ci_machine_user.name
+  policy      = data.aws_iam_policy_document.s3_read_for_user.json
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,9 @@
 data "aws_caller_identity" "current" {}
 
-
 resource "aws_iam_user" "circle_ci_machine-user" {
-  name                 = "${var.name_prefix}-circle-ci"
-  path                 = "/machine-user/"
-  force_destroy        = "true"
+  name          = "${var.name_prefix}-circle-ci"
+  path          = "/machine-user/"
+  force_destroy = "true"
 }
 
 resource "aws_iam_access_key" "circle_ci_machine_user" {

--- a/main.tf
+++ b/main.tf
@@ -26,20 +26,20 @@ resource "aws_ssm_parameter" "pipeline-ci-user-key" {
 
 resource "aws_iam_user_policy" "s3_write_for_user" {
   count       = length(var.allowed_s3_write_arns) > 0 ? 1 : 0
-  description = "This policy allows push and list access to specific S3 buckets."
+  name_prefix = "${var.name_prefix}-circleci-s3-write"
   policy      = data.aws_iam_policy_document.s3_write_to_user.json
 }
 
 resource "aws_iam_user_policy" "ecr_to_user" {
   count       = length(var.allowed_ecr_arns) > 0 ? 1 : 0
-  description = "This policy allows push access to specific ECR repos."
+  name_prefix = "${var.name_prefix}-circleci-ecr"
   user        = aws_iam_user.circle_ci_machine-user.name
   policy      = data.aws_iam_policy_document.ecr_for_user.json
 }
 
 resource "aws_iam_user_policy" "s3_read_for_user" {
   count       = length(var.allowed_s3_read_arns) > 0 ? 1 : 0
-  description = "This policy allows read access to specific S3 buckets."
+  name_prefix = "${var.name_prefix}-circleci-s3-read"
   user        = aws_iam_user.circle_ci_machine-user.name
   policy      = data.aws_iam_policy_document.s3_read_for_user.json
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "user_name" {
-  value = aws_iam_user.circle_ci_machine_user.name
+  value = aws_iam_user.circle_ci_machine-user.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "user_name" {
+  value = aws_iam_user.circle_ci_machine_user.name
+}

--- a/policies.tf
+++ b/policies.tf
@@ -1,0 +1,58 @@
+data "aws_iam_policy_document" "ecr_for_user" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+    ]
+    resources = var.allowed_ecr_arns
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "s3_write_for_user" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:List*",
+    ]
+    resources = concat(var.allowed_s3_arns, formatlist("%s/*", var.allowed_s3_arns))
+  }
+}
+
+data "aws_iam_policy_document" "s3_read_for_user" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+    resources = concat(var.allowed_s3_arns, formatlist("%s/*", var.allowed_s3_arns))
+  }
+}

--- a/policies.tf
+++ b/policies.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "s3_write_for_user" {
       "s3:PutObject",
       "s3:List*",
     ]
-    resources = concat(var.allowed_s3_arns, formatlist("%s/*", var.allowed_s3_arns))
+    resources = concat(var.allowed_s3_write_arns, formatlist("%s/*", var.allowed_s3_write_arns))
   }
 }
 
@@ -53,6 +53,6 @@ data "aws_iam_policy_document" "s3_read_for_user" {
       "s3:Get*",
       "s3:List*",
     ]
-    resources = concat(var.allowed_s3_arns, formatlist("%s/*", var.allowed_s3_arns))
+    resources = concat(var.allowed_s3_read_arns, formatlist("%s/*", var.allowed_s3_read_arns))
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,35 +2,30 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
-variable "allowed_s3_arns" {
-  default = []
-  type    = list(string)
+variable "allowed_s3_write_arns" {
+  description = "A list of ARNs of S3 buckets that the user can write to."
+  default     = []
+  type        = list(string)
 }
 
-variable "allowed_s3_count" {
-  default = 0
-}
-
-variable "allowed_ecr_count" {
-  default = 0
+variable "allowed_s3_read_arns" {
+  description = "A list of ARNs of S3 buckets that the user can read from."
+  default     = []
+  type        = list(string)
 }
 
 variable "allowed_ecr_arns" {
-  default = []
-  type    = list(string)
+  description = "A list of ARNs of ECR repositories that the user can read from and write to."
+  default     = []
+  type        = list(string)
 }
 
 variable "ci_parameters_key" {
+  description = "The ID or ARN of a KMS key or alias to use for encrypting the credentials when storing them in Parameter Store."
 }
 
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = map(string)
   default     = {}
-}
-
-variable "permissions_boundary" {
-  description = "The ARN of a permissions boundary for any IAM resources created to include"
-  type        = string
-  default     = ""
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
- Add a variable for granting read access to S3 buckets
- Output the name of the user to make it easy to add policies outside of the module if necessary
- Remove unused code
- Simplify code

## Breaking changes
- Remove `_count` variables
- Rename input variables
The most important backwards-compatibility is to avoid recreating the IAM user credentials. I tested upgrading from `2eaa652`, and only policies were destroyed and recreated.

It is however worth noting that upgrading from an old version (e.g., `66a7cda`) will most likely require recreation of IAM user and access keys, as there have been many breaking changes in the meantime (e.g., adding name prefixes, etc.).
