### PR TITLE
Avoid inline policies due to size limit of 2048 bytes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,23 +24,43 @@ resource "aws_ssm_parameter" "pipeline-ci-user-key" {
   key_id = var.ci_parameters_key
 }
 
-resource "aws_iam_user_policy" "s3_write_for_user" {
+# NOTE: We create separate policy resources instead of inline policies (e.g., using `aws_iam_user_policy`)
+# due to a size limit of 2048 bytes on inline policies -- a limit that is fairly easy to hit.
+resource "aws_iam_policy" "s3_write" {
   count       = length(var.allowed_s3_write_arns) > 0 ? 1 : 0
   name_prefix = "${var.name_prefix}-circleci-s3-write"
-  user        = aws_iam_user.circle_ci_machine-user.name
+  description = "Policy that grants write access to a list of S3 buckets."
   policy      = data.aws_iam_policy_document.s3_write_for_user.json
 }
 
-resource "aws_iam_user_policy" "ecr_to_user" {
+resource "aws_iam_policy" "s3_read" {
+  count       = length(var.allowed_s3_read_arns) > 0 ? 1 : 0
+  name_prefix = "${var.name_prefix}-circleci-s3-read"
+  description = "Policy that grants read access to a list of S3 buckets."
+  policy      = data.aws_iam_policy_document.s3_read_for_user.json
+}
+
+resource "aws_iam_policy" "ecr" {
   count       = length(var.allowed_ecr_arns) > 0 ? 1 : 0
   name_prefix = "${var.name_prefix}-circleci-ecr"
-  user        = aws_iam_user.circle_ci_machine-user.name
+  description = "Policy that grants read and write access to a list of ECR repositories."
   policy      = data.aws_iam_policy_document.ecr_for_user.json
 }
 
-resource "aws_iam_user_policy" "s3_read_for_user" {
-  count       = length(var.allowed_s3_read_arns) > 0 ? 1 : 0
-  name_prefix = "${var.name_prefix}-circleci-s3-read"
-  user        = aws_iam_user.circle_ci_machine-user.name
-  policy      = data.aws_iam_policy_document.s3_read_for_user.json
+resource "aws_iam_user_policy_attachment" "s3_write_to_user" {
+  count      = length(aws_iam_policy.s3_write)
+  user       = aws_iam_user.circle_ci_machine-user.name
+  policy_arn = aws_iam_policy.s3_write[0].arn
+}
+
+resource "aws_iam_user_policy_attachment" "s3_read_to_user" {
+  count      = length(aws_iam_policy.s3_read)
+  user       = aws_iam_user.circle_ci_machine-user.name
+  policy_arn = aws_iam_policy.s3_read[0].arn
+}
+
+resource "aws_iam_user_policy_attachment" "ecr_to_user" {
+  count      = length(aws_iam_policy.ecr)
+  user       = aws_iam_user.circle_ci_machine-user.name
+  policy_arn = aws_iam_policy.ecr[0].arn
 }


### PR DESCRIPTION
Inline policies are limited to a size of 2048 bytes, which is fairly easy to hit if you have 10-15 buckets or ECR repositories. 

This PR creates separate policy resources instead, which increases the size limit to 6000 characters or so. If we start hitting these limits as well, we may need to use IAM groups or start chunking up the policies.