### PR TITLE
Use a known value in count instead of dynamic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,16 +51,19 @@ resource "aws_iam_user_policy_attachment" "s3_write_to_user" {
   count      = length(var.allowed_s3_write_arns) > 0 ? 1 : 0
   user       = aws_iam_user.circle_ci_machine-user.name
   policy_arn = aws_iam_policy.s3_write[0].arn
+  depends_on = [aws_iam_policy.s3_write]
 }
 
 resource "aws_iam_user_policy_attachment" "s3_read_to_user" {
   count      = length(var.allowed_s3_read_arns) > 0 ? 1 : 0
   user       = aws_iam_user.circle_ci_machine-user.name
   policy_arn = aws_iam_policy.s3_read[0].arn
+  depends_on = [aws_iam_policy.s3_read]
 }
 
 resource "aws_iam_user_policy_attachment" "ecr_to_user" {
   count      = length(var.allowed_ecr_arns) > 0 ? 1 : 0
   user       = aws_iam_user.circle_ci_machine-user.name
   policy_arn = aws_iam_policy.ecr[0].arn
+  depends_on = [aws_iam_policy.ecr]
 }

--- a/main.tf
+++ b/main.tf
@@ -48,19 +48,19 @@ resource "aws_iam_policy" "ecr" {
 }
 
 resource "aws_iam_user_policy_attachment" "s3_write_to_user" {
-  count      = length(aws_iam_policy.s3_write)
+  count      = length(var.allowed_s3_write_arns) > 0 ? 1 : 0
   user       = aws_iam_user.circle_ci_machine-user.name
   policy_arn = aws_iam_policy.s3_write[0].arn
 }
 
 resource "aws_iam_user_policy_attachment" "s3_read_to_user" {
-  count      = length(aws_iam_policy.s3_read)
+  count      = length(var.allowed_s3_read_arns) > 0 ? 1 : 0
   user       = aws_iam_user.circle_ci_machine-user.name
   policy_arn = aws_iam_policy.s3_read[0].arn
 }
 
 resource "aws_iam_user_policy_attachment" "ecr_to_user" {
-  count      = length(aws_iam_policy.ecr)
+  count      = length(var.allowed_ecr_arns) > 0 ? 1 : 0
   user       = aws_iam_user.circle_ci_machine-user.name
   policy_arn = aws_iam_policy.ecr[0].arn
 }


### PR DESCRIPTION
Terraform will fail if you pass in an empty list to `var.allowed_s3_write_arns`, `var.allowed_s3_read_arns` and `var.allowed_ecr_arns`, as the `count` is referencing a value that is not known until the module has actually been applied.

This PR uses a known value for the count instead, and also adds a `depends_on` to each of the policy attachments such that the attachments are created after the policies.